### PR TITLE
add and install fribidi for RTL languages

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -24,7 +24,7 @@ matches:
       - name: "output"
         type: shell
         params:
-          cmd: "trans -b -t '{{input.target}}' '{{input.text}}'"
+          cmd: "trans -b -t '{{input.target}}' '{{input.text}}' | fribidi --rtl"
           shell: wsl
 
   - trigger: "::etrans"
@@ -60,7 +60,7 @@ matches:
       - name: "output"
         type: shell
         params:
-          cmd: "trans -b -s '{{input.source}}' -t '{{input.target}}' '{{input.text}}'"
+          cmd: "trans -b -s '{{input.source}}' -t '{{input.target}}' '{{input.text}}' | fribidi --rtl"
           shell: wsl
 
 global_vars:


### PR DESCRIPTION
so for right to left (RTL) languages like: Arabic, Hebrew and Persian.
it would print the letters reversed for example:
printing quick --> kciuq
so I have tried using RTL markers and unicodes but didnt work. 
tried letting wsl shell handle it but also printed in reverse.
tried using other translate packages instead of translate-shell like: googletrans or camel tools but it was lots of change and had its own issues.
the only simple and quick fix was installing fribidi within wsl and using its rtl feature which worked pretty decent except for diacritical marks AKA (accents)  